### PR TITLE
Ensure presence of URLBase key

### DIFF
--- a/SSDPBrowser.m
+++ b/SSDPBrowser.m
@@ -69,8 +69,16 @@
 			NSURLSessionTask *task = [NSURLSession.sharedSession dataTaskWithURL:url completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
 				if (self.titleByUUID[uuid] == nil && data.length > 0) {
 					XMLToDictBuilder *xmlToDict = XMLToDictBuilder.new;
-					NSDictionary *dict = [xmlToDict parseData:data];
+					NSMutableDictionary *dict = [[xmlToDict parseData:data] mutableCopy];
 					NSString *friendlyName = dict[@"root"][@"device"][@"friendlyName"];
+					if (dict[@"root"][@"URLBase"] == nil) {
+						NSRange range = [service.location rangeOfString:@"\\b/\\b" options:NSRegularExpressionSearch];
+						if (range.location != NSNotFound) {
+							dict[@"root"][@"URLBase"] = [service.location substringToIndex:range.location];
+						} else {
+							dict[@"root"][@"URLBase"] = service.location;
+						}
+					}
 					self.titleByUUID[uuid] = friendlyName;
 					dispatch_async(dispatch_get_main_queue(), ^{
 						[self.delegate browser:self didFindUUID:uuid name:friendlyName data:dict];

--- a/SSDPBrowser.m
+++ b/SSDPBrowser.m
@@ -74,9 +74,9 @@
 					if (dict[@"root"][@"URLBase"] == nil) {
 						NSRange range = [service.location rangeOfString:@"\\b/\\b" options:NSRegularExpressionSearch];
 						if (range.location != NSNotFound) {
-							dict[@"root"][@"URLBase"] = [service.location substringToIndex:range.location];
+							dict[@"root"][@"URLBase (inferred)"] = [service.location substringToIndex:range.location];
 						} else {
-							dict[@"root"][@"URLBase"] = service.location;
+							dict[@"root"][@"URLBase (inferred)"] = service.location;
 						}
 					}
 					self.titleByUUID[uuid] = friendlyName;


### PR DESCRIPTION
This change will facilitate injection of `URLBase` keys into device service descriptions lacking them by using the `LOCATION` header's value from the initial query. Without that information rendered into the UI, then users cannot infer how to access remote URIs such as those specified by the `SCPDURL` field.