### PR TITLE
Clipboard support

### DIFF
--- a/AppDelegate.h
+++ b/AppDelegate.h
@@ -6,6 +6,9 @@
 //
 
 #import <Cocoa/Cocoa.h>
+#import "TreeNode.h"
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
+	@property NSClickGestureRecognizer *gesture;
+	@property TreeNode *node;
 @end

--- a/AppDelegate.m
+++ b/AppDelegate.m
@@ -6,6 +6,7 @@
 //
 
 #import "AppDelegate.h"
+#import "HighlightingTextFieldCell.h"
 
 @interface AppDelegate ()
 @end
@@ -14,6 +15,23 @@
 
 - (BOOL)applicationShouldTerminateAfterLastWindowClosed:(NSApplication *)sender {
 	return YES;
+}
+
+- (void)applicationDidFinishLaunching:(NSNotification *) notification {
+	self.gesture = NSClickGestureRecognizer.new;
+	self.gesture.buttonMask = 0x1;
+	self.gesture.numberOfClicksRequired = 2;
+	self.gesture.target = self;
+	self.gesture.action = @selector(onClick:);
+	self.node = nil;
+}
+
+- (void)onClick:(NSGestureRecognizer *) sender {
+	if (self.node != nil && self.node.value != nil) {
+		NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+		[pasteboard clearContents];
+		[pasteboard setString:self.node.value forType:NSPasteboardTypeString];
+	}
 }
 
 @end

--- a/HighlightingTextFieldCell.m
+++ b/HighlightingTextFieldCell.m
@@ -8,6 +8,8 @@
 
 #import "HighlightingTextFieldCell.h"
 #import "SSDPDocument.h"
+#import "AppDelegate.h"
+#import "TreeNode.h"
 
 @implementation HighlightingTextFieldCell
 
@@ -20,6 +22,10 @@
 //
 - (void)setObjectValue:(id)objectValue {
 	if ([objectValue isKindOfClass:TreeNode.class]) {
+		//NSLog(@"%p", objectValue);
+		[self setEnabled:true];
+		[(NSTextField*)self.controlView setEnabled:true];
+		[(NSTextField*)self.controlView addGestureRecognizer:((AppDelegate*)[NSApplication sharedApplication].delegate).gesture];
 		// we want to replace the string with an attributed string if there's a search filter set
 		id docHandler = self.controlView.window.delegate;	// we blindly assume this is of the SSDPDocument type
 		objectValue = [(SSDPDocument*)docHandler highlightedObjectValue:self node:objectValue];

--- a/SSDPDocument.m
+++ b/SSDPDocument.m
@@ -7,6 +7,7 @@
 
 #import "SSDPDocument.h"
 #import "TreeNode.h"
+#import "AppDelegate.h"
 
 #if 1
 	#import "SSDPBrowser.h"
@@ -14,7 +15,7 @@
 	#import "SSDP_Browser-Swift.h"
 #endif
 
-@interface SSDPDocument () <SSDPBrowserDelegate, NSSearchFieldDelegate, NSOutlineViewDataSource>
+@interface SSDPDocument () <SSDPBrowserDelegate, NSSearchFieldDelegate, NSOutlineViewDataSource, NSOutlineViewDelegate>
 	@property (weak) IBOutlet NSProgressIndicator *searchSpinner;
 	@property (weak) IBOutlet NSOutlineView *outlineView;
 	@property (strong) IBOutlet NSTreeController *treeController;
@@ -29,8 +30,8 @@
 @implementation SSDPDocument
 
 - (instancetype)init {
-    self = [super init];
-    if (self) {
+	self = [super init];
+	if (self) {
 		self.model = TreeNode.new;
 		self.browser = SSDPBrowser.new;
 		if (@available(macOS 10.13, *)) {
@@ -44,8 +45,8 @@
 				NSBackgroundColorAttributeName:[NSColor secondarySelectedControlColor]
 			};
 		}
-    }
-    return self;
+	}
+	return self;
 }
 
 + (BOOL)autosavesInPlace {
@@ -62,6 +63,16 @@
 		[NSSortDescriptor sortDescriptorWithKey:@"name" ascending:YES],
 		[NSSortDescriptor sortDescriptorWithKey:@"value" ascending:YES]
 	]];
+	self.outlineView.delegate = self;
+}
+
+#pragma mark - NSOutlineViewDelegate
+
+- (void)outlineViewSelectionDidChange:(NSNotification *) notification {
+	id item = ((NSTreeNode*)[self.outlineView itemAtRow:self.outlineView.selectedRow]).representedObject;
+	if ([item isKindOfClass:TreeNode.class]) {
+		((AppDelegate*)[NSApplication sharedApplication].delegate).node = (TreeNode*)item;
+	}
 }
 
 #pragma mark - NSOutlineViewDataSource delegate


### PR DESCRIPTION
With these changes, users can now double-left-click on any row node in the tree document display table in order to put the associated value string into the OS clipboard so that that data may be pasted into other applications' text fields.